### PR TITLE
Add private messaging feature

### DIFF
--- a/include/client/client.h
+++ b/include/client/client.h
@@ -8,6 +8,7 @@
 #define ADD_WORD_BLACKLIST_COMMAND "!add_blacklist"
 #define SHOW_BLACKLIST_COMMAND "!show_blacklist"
 #define HELP_BLACKLIST "!blacklist"
+#define PRIVATE_MESSAGE_COMMAND "!pm"
 
 #define CLOSE_PROGRAM_COMMAND "!close_program"
 #define LEAVE_GROUP_COMMAND "!leave_group"

--- a/include/common/protocol.h
+++ b/include/common/protocol.h
@@ -12,7 +12,9 @@ typedef enum request_type_t
     LOGIN,                 /* Login message type */
     LOGOUT,                /* Logout message type */
     SEND_MESSAGE,          /* Send message type */
+    SEND_PRIVATE_MESSAGE,  /* Send a private message */
     RECEIEVE_MESSAGE,      /* Receive message type */
+    RECEIVE_PRIVATE_MESSAGE, /* Receive private message */
     CREATE_GROUP,          /* Create group message type */
     JOIN_GROUP,            /* Join group message type */
     LEAVE_GROUP,           /* Leave group message type */
@@ -72,6 +74,12 @@ typedef struct protocol_message_t
         {
             char words[MAX_WORDS_BLACKLIST * MAX_WORD_LENGTH];
         } blacklist_words;
+
+        struct private_message_t
+        {
+            char recipient[MAX_USERNAME_LENGTH];
+            char content[MAX_CONTENT_LENGTH];
+        } privateMessage;
         struct
         {
             int groupID;
@@ -93,7 +101,7 @@ void sendMessage(int sock, RequestMessage *message);
  * @param sock The socket to send the message on.
  * @param message The chat message to send.
  */
-void sendChatMessage(int sock, chatMessage *message);
+void sendChatMessage(int sock, chatMessage *message, MessageType type);
 
 /**
  * sends a ResponseMessage from a socket.

--- a/include/server/UsersArray.h
+++ b/include/server/UsersArray.h
@@ -54,6 +54,11 @@ void updateUserGroupId(Users *users, int fd, int group_id);
 int checkUsernameExists(Users *users, char *username);
 
 /**
+ * Retrieves a user's file descriptor by username.
+ */
+int getFdByUsername(Users *users, char *username);
+
+/**
  * @brief Prints the array of users.
  * 
  * @param users The pointer to the Users object.

--- a/include/server/server.h
+++ b/include/server/server.h
@@ -63,6 +63,11 @@ void handleGroupCreation(int current_fd, char *username, RequestMessage message,
 void handleSendMessage(int current_fd, char *username, RequestMessage message, ResponseMessage response);
 
 /**
+ * Handles sending a private message to another user.
+ */
+void handlePrivateMessage(int current_fd, char *username, RequestMessage message, ResponseMessage *response);
+
+/**
  * @brief Handles the "Show Blacklist" command received from a client.
  * 
  * @param current_fd The file descriptor of the client connection.

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -277,6 +277,24 @@ void handleUserMessageInGroup(int sock, RequestMessage message, char *buffer)
     strncpy(message.request.sendMessage.message.content, buffer, MAX_CONTENT_LENGTH);
     message.request.sendMessage.message.content[strcspn(message.request.sendMessage.message.content, "\n")] = '\0';
 
+    if (strncmp(buffer, PRIVATE_MESSAGE_COMMAND, strlen(PRIVATE_MESSAGE_COMMAND)) == 0)
+    {
+        char *ptr = buffer + strlen(PRIVATE_MESSAGE_COMMAND);
+        while (*ptr == ' ') ptr++;
+        char *recipient = strtok(ptr, " ");
+        char *content = strtok(NULL, "");
+        if (recipient == NULL || content == NULL)
+        {
+            print_bold_by_color("Usage: !pm <user> <message>\n", RED);
+            return;
+        }
+        message.type = SEND_PRIVATE_MESSAGE;
+        strncpy(message.request.privateMessage.recipient, recipient, MAX_USERNAME_LENGTH);
+        strncpy(message.request.privateMessage.content, content, MAX_CONTENT_LENGTH);
+        sendMessage(sock, &message);
+        return;
+    }
+
     if (strcmp(message.request.sendMessage.message.content, "") == 0)
     {
         print_bold_by_color("You can't send an empty message\n", RED);
@@ -429,6 +447,10 @@ void handleServerResponse(int sock, ResponseMessage *response)
         break;
     case RECEIEVE_MESSAGE:
         print_bold_by_color("Received message\n", GREEN);
+        printChatMessage(response->message);
+        break;
+    case RECEIVE_PRIVATE_MESSAGE:
+        print_bold_by_color("Private message\n", GREEN);
         printChatMessage(response->message);
         break;
     case CREATE_GROUP:

--- a/src/common/protocol.c
+++ b/src/common/protocol.c
@@ -8,10 +8,10 @@ void sendMessage(int sock, RequestMessage *message)
     send(sock, message, sizeof(RequestMessage) - sizeof(char *), 0);
 }
 
-void sendChatMessage(int sock, chatMessage *message)
+void sendChatMessage(int sock, chatMessage *message, MessageType type)
 {
     ResponseMessage response;
-    response.type = RECEIEVE_MESSAGE;
+    response.type = type;
     response.status = SUCCESS;
     response.message = *message;
 

--- a/src/server/UsersArray.c
+++ b/src/server/UsersArray.c
@@ -81,6 +81,18 @@ int checkUsernameExists(Users *users, char *username)
     return USER_NOT_FOUND;
 }
 
+int getFdByUsername(Users *users, char *username)
+{
+    for (int i = 0; i < users->count; i++)
+    {
+        if (strcmp(users->users_arr[i].username, username) == 0)
+        {
+            return users->users_arr[i].fd;
+        }
+    }
+    return USER_NOT_FOUND;
+}
+
 void printUsers(Users *users)
 {
     printf("Going to print users\n");

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -300,6 +300,9 @@ void handleClientRequest(int current_fd, int new_socket, RequestMessage message,
         // Handle send message
         handleSendMessage(current_fd, username, message, response);
         break;
+    case SEND_PRIVATE_MESSAGE:
+        handlePrivateMessage(current_fd, username, message, &response);
+        break;
     case CREATE_GROUP:
         // Handle create group
         handleGroupCreation(current_fd, username, message, response);
@@ -374,6 +377,33 @@ void handleSendMessage(int current_fd, char *username, RequestMessage message, R
     response.type = SEND_MESSAGE;
     response.description = "Message sent successfully\n";
     sendResponse(current_fd, &response);
+}
+
+void handlePrivateMessage(int current_fd, char *username, RequestMessage message, ResponseMessage *response)
+{
+    char *recipient = message.request.privateMessage.recipient;
+    int target_fd = getFdByUsername(users, recipient);
+
+    if (target_fd == USER_NOT_FOUND)
+    {
+        response->status = ERROR;
+        response->type = SEND_PRIVATE_MESSAGE;
+        response->description = "User not found\n";
+        sendResponse(current_fd, response);
+        return;
+    }
+
+    chatMessage chat_message;
+    strncpy(chat_message.content, message.request.privateMessage.content, MAX_CONTENT_LENGTH);
+    chat_message.sender = *(getUser(users, current_fd));
+    chat_message.timestamp = time(NULL);
+
+    sendChatMessage(target_fd, &chat_message, RECEIVE_PRIVATE_MESSAGE);
+
+    response->status = SUCCESS;
+    response->type = SEND_PRIVATE_MESSAGE;
+    response->description = "Private message sent\n";
+    sendResponse(current_fd, response);
 }
 
 void handleGroupCreation(int current_fd, char *username, RequestMessage message, ResponseMessage response)
@@ -487,7 +517,7 @@ int sendMessageToGroup(int sender, int group_id, chatMessage message)
     {
         if (member_fds[i] != sender)
         {
-            sendChatMessage(member_fds[i], &message);
+            sendChatMessage(member_fds[i], &message, RECEIEVE_MESSAGE);
         }
     }
     return 0;


### PR DESCRIPTION
## Summary
- introduce private messaging commands and message types
- add helper to look up user by name
- handle SEND_PRIVATE_MESSAGE on server and client
- update protocol message structures

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_685f03b7ef28832e8b9f6a4341a64646